### PR TITLE
Ignore `.cache` directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 # stackbit
 .sourcebit-nextjs-cache.json
 .stackbit/dynamic-components.js
+/.cache
 
 # testing
 /coverage


### PR DESCRIPTION
This is used by `stackbit dev`. I ended up with a lot of tracked changes when running stackbit dev within the project.