### PR TITLE
Ignore `.envrc`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ yarn-error.log*
 .env.development.local
 .env.test.local
 .env.production.local
+.envrc
 
 # IDE
 *.code-workspace


### PR DESCRIPTION
This is what I use for project-specific env vars. Not sure if we want to include this for everyone? Maybe it's just something that I would do on new projects?