### PR TITLE
fix: remove blocking code on redirects

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -15,14 +15,14 @@ module.exports = withBundleAnalyzer({
         // Allow production builds to successfully complete even if your project has ESLint errors.
         ignoreDuringBuilds: true
     },
-    redirects: async () => {
-        // wait for sourcebit to generate sourecbit-nextjs-cache file before proceeding to load tailwind config
-        if (!devServerStarted) {
-            devServerStarted = true;
-            await sourcebit.fetch(sourcebitConfig);
-        }
-        return [];
-    },
+    // redirects: async () => {
+    //     // wait for sourcebit to generate sourecbit-nextjs-cache file before proceeding to load tailwind config
+    //     if (!devServerStarted) {
+    //         devServerStarted = true;
+    //         await sourcebit.fetch(sourcebitConfig);
+    //     }
+    //     return [];
+    // },
     webpack: (config, { webpack, dev }) => {
         // Tell webpack to ignore watching content files in the content folder.
         // Otherwise webpack recompiles the app and refreshes the whole page.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-    "name": "starter-nextjs-theme",
-    "version": "0.1.0",
+    "name": "starter-nextjs-contentful-theme",
+    "version": "0.1.1",
     "engines": {
         "node": ">=14 <16",
         "npm": "~6"


### PR DESCRIPTION
This does not play well with concurrency,
and will lead to the cache file being deleted while it is in the process
of being read, under certain edge-cases